### PR TITLE
[201911][Mellanox]Adding mlsxw debug patch

### DIFF
--- a/patch/0081-DBG-mlxsw-i2c-Add-retries-for-transaction-for-settin.patch
+++ b/patch/0081-DBG-mlxsw-i2c-Add-retries-for-transaction-for-settin.patch
@@ -1,0 +1,102 @@
+From 776a5f7316c886c7c3fd8bc9c6ad8f2ab9b14017 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Sun, 7 Aug 2022 15:37:02 +0300
+Subject: [PATCH backport 4.9 net 1/1] DBG: mlxsw: i2c: Add retries for
+ transaction for setting control buffer
+
+Currently I2C transaction used to prepare control register for sending
+transaction to ASIC and setting "go" bit in this register are not
+re-tried. Add retries in case these transactions are replied with NACK.
+
+The purpose of this patch is for debugging I2C transaction failures
+found on some MSFT SN2700 systems.
+In case one of two kinds of transactions is failed, transaction is to
+be re-tried until success or until both 5000 milliseconds time-out
+window and retries counter 5 are expired.
+
+In I2C tracing those transactions fulures looks like:
+/* Write out Command Interface Register GO bit to push transaction */
+3694103.430778: i2c_write: i2c-2 #0 a=048 f=0000 l=8 [00-07-20-18-00-80-00-40]
+3694103.432085: i2c_result: i2c-2 n=0 ret=-6	-> NACK
+
+/* Prepare Command Interface Register for transaction */
+3694105.144816: i2c_write: i2c-2 #0 a=048 f=0000 l=32 [00-07-20-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-02-00-00-00-40]
+3694105.148196: i2c_result: i2c-2 n=0 ret=-6	-> NACK
+
+In case retry counter is not zero, does not matter if transaction is
+completed or failed, log with number of retries, timer value in jiffies
+and error code will be produced in dmesg.
+
+Note:
+It is recommended on systems with this patch applied to run
+asic-fail-v{n}.sh script for intercept i2c traces from CPU end prior
+I2C transaction failures.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/i2c.c | 37 ++++++++++++++++++++---
+ 1 file changed, 32 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/i2c.c b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+index 1205c6111b0b..3657d1ece5fb 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/i2c.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+@@ -195,7 +195,8 @@ static int mlxsw_i2c_write_cmd(struct i2c_client *client,
+ 				    MLXSW_I2C_PUSH_CMD_SIZE);
+ 	struct i2c_msg prep_cmd =
+ 		MLXSW_I2C_WRITE_MSG(client, prep_cmd_buf, MLXSW_I2C_PREP_SIZE);
+-	int err;
++	unsigned long end;
++	int i, err;
+ 
+ 	if (!immediate) {
+ 		push_cmd_buf[1] = cpu_to_be32(MLXSW_I2C_PUSH_CMD);
+@@ -206,15 +207,41 @@ static int mlxsw_i2c_write_cmd(struct i2c_client *client,
+ 	mlxsw_i2c_set_slave_addr((u8 *)push_cmd_buf,
+ 				 MLXSW_I2C_CIR2_OFF_STATUS);
+ 
+-	/* Prepare Command Interface Register for transaction */
+-	err = i2c_transfer(client->adapter, &prep_cmd, 1);
++	end = jiffies + msecs_to_jiffies(MLXSW_I2C_TIMEOUT_MSECS);
++	i = 0;
++	do {
++		/* Prepare Command Interface Register for transaction */
++		err = i2c_transfer(client->adapter, &prep_cmd, 1);
++		if (err == 1)
++			break;
++		cond_resched();
++	} while ((time_before(jiffies, end)) || (i++ < MLXSW_I2C_RETRY));
++
++	/* Add debug log */
++	if (i)
++		dev_err(&client->dev, "Setting CIR_BMC after %d retries, timer armed at %lu stopped at %lu with err=%d",
++			i, jiffies, end, err);
++
+ 	if (err < 0)
+ 		return err;
+ 	else if (err != 1)
+ 		return -EIO;
+ 
+-	/* Write out Command Interface Register GO bit to push transaction */
+-	err = i2c_transfer(client->adapter, &push_cmd, 1);
++	end = jiffies + msecs_to_jiffies(MLXSW_I2C_TIMEOUT_MSECS);
++	i = 0;
++	do {
++		/* Write out Command Interface Register GO bit to push transaction */
++		err = i2c_transfer(client->adapter, &push_cmd, 1);
++		if (err == 1)
++			break;
++		cond_resched();
++	} while ((time_before(jiffies, end)) || (i++ < MLXSW_I2C_RETRY));
++
++	/* Add debug log */
++	if (i)
++		dev_err(&client->dev, "Setting GO bit in CIR_BMC after %d retries, timer armed at %lu stopped at %lu with err=%d",
++			i, jiffies, end, err);
++
+ 	if (err < 0)
+ 		return err;
+ 	else if (err != 1)
+-- 
+2.20.1
+

--- a/patch/series
+++ b/patch/series
@@ -120,6 +120,7 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0078-mlxsw-core-Add-validation-of-transceiver-temperature.patch
 0079-mlxsw-core-Remove-critical-trip-point-from-thermal-z.patch
 0080-mlxsw-i2c-Prevent-transaction-execution-for-spec.patch
+0081-DBG-mlxsw-i2c-Add-retries-for-transaction-for-settin.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch


### PR DESCRIPTION
Adding a debug patch to retry i2c transactions on failure. 
Currently I2C transaction used to prepare control register for sending transaction to ASIC and setting "go" bit in this register are not re-tried. Add retries in case these transactions are replied with NACK.The purpose of this patch is for debugging I2C transaction failures found on some MSFT SN2700 systems.In case one of two kinds of transactions is failed, transaction is to
be re-tried until success or until both 5000 milliseconds time-out
window and retries counter 5 are expired.