### PR TITLE
Update Makefile to provision the ability of building with non-upstream patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Precedence is given for external URL
 	if [ -z ${EXTERNAL_KERNEL_PATCHES} ] && [ x${INCLUDE_MLNX_PATCHES} == xy ]; then
 		if [ -f "$(MLNX_PATCH_LOC)" ]; then
-			tar $(MLNX_PATCH_LOC) -C $(NON_UP_LOC)
+			tar -zxf $(MLNX_PATCH_LOC) -C $(NON_UP_LOC)
 		fi
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# Precedence is given for external URL
 	if [ -z ${EXTERNAL_KERNEL_PATCHES} ] && [ x${INCLUDE_MLNX_PATCHES} == xy ]; then
-		if [ -f "../../../$(MLNX_PATCH_LOC)" ]; then
+		if [ -f "$(MLNX_PATCH_LOC)" ]; then
 			tar $(MLNX_PATCH_LOC) -C $(NON_UP_LOC)
 		fi
 	fi

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ SOURCE_FILE_BASE_URL="https://sonicstorage.blob.core.windows.net/debian-security
 DSC_FILE_URL = "$(SOURCE_FILE_BASE_URL)/$(DSC_FILE)"
 DEBIAN_FILE_URL = "$(SOURCE_FILE_BASE_URL)/$(DEBIAN_FILE)"
 ORIG_FILE_URL = "$(SOURCE_FILE_BASE_URL)/$(ORIG_FILE)"
-NON_UP_LOC = non_upstream_patches
+NON_UP_DIR = /tmp/non_upstream_patches
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Obtaining the Debian kernel source
@@ -100,24 +100,25 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	stg repair
 	stg import -s ../patch/series
 
-	mkdir $(NON_UP_LOC)
+	rm -rf $(NON_UP_DIR)
+	mkdir -p $(NON_UP_DIR)
 
-	if [ ! -z ${EXTERNAL_KERNEL_PATCHES} ];  then
-		wget ${EXTERNAL_KERNEL_PATCHES} -O patches.tar
-		tar -xf patches.tar -C $(NON_UP_LOC)
+	if [ ! -z ${EXTERNAL_KERNEL_PATCH_URL} ];  then
+		wget ${EXTERNAL_KERNEL_PATCH_URL} -O patches.tar
+		tar -xf patches.tar -C $(NON_UP_DIR)
 	fi
 
 	# Precedence is given for external URL
-	if [ -z ${EXTERNAL_KERNEL_PATCHES} ] && [ x${INCLUDE_MLNX_PATCHES} == xy ]; then
-		if [ -f "$(MLNX_PATCH_LOC)" ]; then
-			tar -xf $(MLNX_PATCH_LOC) -C $(NON_UP_LOC)
+	if [ -z ${EXTERNAL_KERNEL_PATCH_URL} ] && [ x${INCLUDE_EXTERNAL_PATCH_TAR} == xy ]; then
+		if [ -f "$(EXTERNAL_KERNEL_PATCH_TAR)" ]; then
+			tar -xf $(EXTERNAL_KERNEL_PATCH_TAR) -C $(NON_UP_DIR)
 		fi
 	fi
 
-	if [ -f "$(NON_UP_LOC)/series" ]; then
+	if [ -f "$(NON_UP_DIR)/series" ]; then
 		echo "External Patches applied:"
-		cat $(NON_UP_LOC)/series
-		stg import -s $(NON_UP_LOC)/series
+		cat $(NON_UP_DIR)/series
+		stg import -s $(NON_UP_DIR)/series
 	fi
 
 	# Optionally add/remove kernel options

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	mkdir $(NON_UP_LOC)
 
 	if [ ! -z ${EXTERNAL_KERNEL_PATCHES} ];  then
-		wget ${EXTERNAL_KERNEL_PATCHES}
-		PATCH_TAR=$(basename ${EXTERNAL_KERNEL_PATCHES})
-		tar -zxf $(PATCH_TAR) -C $(NON_UP_LOC)
+		wget ${EXTERNAL_KERNEL_PATCHES} -O patches.tar.gz
+		tar -zxf patches.tar.gz -C $(NON_UP_LOC)
 	fi
 
 	# Precedence is given for external URL
@@ -116,6 +115,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	fi
 
 	if [ -f "$(NON_UP_LOC)/series" ]; then
+		echo "External Patches applied:"
+		cat $(NON_UP_LOC)/series
 		stg import -s $(NON_UP_LOC)/series
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Precedence is given for external URL
 	if [ -z ${EXTERNAL_KERNEL_PATCHES} ] && [ x${INCLUDE_MLNX_PATCHES} == xy ]; then
 		if [ -f "../../../$(MLNX_PATCH_LOC)" ]; then
-			tar -zxf ../../../$(MLNX_PATCH_LOC) -C $(NON_UP_LOC)
+			tar $(MLNX_PATCH_LOC) -C $(NON_UP_LOC)
 		fi
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -103,14 +103,14 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	mkdir $(NON_UP_LOC)
 
 	if [ ! -z ${EXTERNAL_KERNEL_PATCHES} ];  then
-		wget ${EXTERNAL_KERNEL_PATCHES} -O patches.tar.gz
-		tar -zxf patches.tar.gz -C $(NON_UP_LOC)
+		wget ${EXTERNAL_KERNEL_PATCHES} -O patches.tar
+		tar -xf patches.tar -C $(NON_UP_LOC)
 	fi
 
 	# Precedence is given for external URL
 	if [ -z ${EXTERNAL_KERNEL_PATCHES} ] && [ x${INCLUDE_MLNX_PATCHES} == xy ]; then
 		if [ -f "$(MLNX_PATCH_LOC)" ]; then
-			tar -zxf $(MLNX_PATCH_LOC) -C $(NON_UP_LOC)
+			tar -xf $(MLNX_PATCH_LOC) -C $(NON_UP_LOC)
 		fi
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	mkdir -p $(NON_UP_DIR)
 
 	if [ ! -z ${EXTERNAL_KERNEL_PATCH_URL} ];  then
-		wget ${EXTERNAL_KERNEL_PATCH_URL} -O patches.tar
+		wget $(EXTERNAL_KERNEL_PATCH_URL) -O patches.tar
 		tar -xf patches.tar -C $(NON_UP_DIR)
 	fi
 


### PR DESCRIPTION
Dependent PR: https://github.com/sonic-net/sonic-buildimage/pull/12428

Can be merged in any order