### PR TITLE
Fix setting a config with an already-existing conflicting value

### DIFF
--- a/manage-config
+++ b/manage-config
@@ -115,6 +115,8 @@ if [ -e ${exclusion_file} -o -e ${inclusion_file} -o -e ${force_inclusion_file} 
             if [ ! -z "$opt" ] && [[ ! "$opt" =~ ^#.* ]]; then
                 n=${opt%=*}
                 v="${opt#*=}"
+                v="${v/#\"/}"
+                v="${v/%\"/}"
                 s=$(scripts/config --file ${CONFIG_FILE} -k --state $n)
                 if [ ! "$s" = "$v" ]; then
                     ret=2

--- a/manage-config
+++ b/manage-config
@@ -79,7 +79,9 @@ if [ -e ${exclusion_file} -o -e ${inclusion_file} -o -e ${force_inclusion_file} 
         inclusion_opts=$(get_section_opts ${inclusion_file} "common" ${ARCH} ${PLATFORM})
         while read -r opt; do
             if [ ! -z "$opt" ] && [[ ! "$opt" =~ ^#.* ]]; then
-                echo $opt >> ${CONFIG_FILE}
+                n=${opt%=*}
+                v="${opt#*=}"
+                scripts/config --file ${CONFIG_FILE} -k --set-val "$n" "$v"
             fi
         done <<< ${inclusion_opts};
     fi


### PR DESCRIPTION
Fix setting a config value in kconfig-inclusions when there's already a conflicting existing value in defconfig.

For example, trying to overwrite `CONFIG_SYSTEM_TRUSTED_KEYS` would have no effect, because there's already a value specified in the file, and the existing value takes precedence.

Also support verifying the value of strings (and not just y/m/n settings). `CONFIG_SYSTEM_TRUSTED_KEYS` takes a string value, and the current code doesn't completely handle strings.

Fixes #299.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>