### PR TITLE
Fix unable to probe emc2301/2/3

### DIFF
--- a/patch/0001-hwmon-emc2305-Fix-unable-to-probe-emc2301-2-3.patch
+++ b/patch/0001-hwmon-emc2305-Fix-unable-to-probe-emc2301-2-3.patch
@@ -1,0 +1,57 @@
+From e487bfd66267b942185a7124893c5f496bce768e Mon Sep 17 00:00:00 2001
+From: Natarajan Subbiramani <natarajan.subbiramani.ext@nokia.com>
+Date: Fri, 31 Mar 2023 16:06:56 +0000
+Subject: [PATCH] hwmon: (emc2305) Fix unable to probe emc2301/2/3
+
+The definitions of 'EMC2305_REG_PRODUCT_ID' and 'EMC2305_REG_DEVICE' are
+both '0xfd', they actually return the same value, but the values returned
+by emc2301/2/3/5 are different, so probe emc2301/2/3 will fail, This patch
+fixes that.
+
+Fix is available in upstream:
+https://github.com/torvalds/linux/commit/4d50591ebf60ccf79380fff3a4c23659c61c482f
+
+Signed-off-by: Natarajan Subbiramani <natarajan.subbiramani.ext@nokia.com>
+Signed-off-by: Xingjiang Qiao <nanpuyue@gmail.com>
+Link: https://lore.kernel.org/r/20221206055331.170459-1-nanpuyue@gmail.com
+Fixes: 0d8400c ("hwmon: (emc2305) add support for EMC2301/2/3/5 RPM-based PWM Fan Speed Controller.")
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ drivers/hwmon/emc2305.c | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/drivers/hwmon/emc2305.c b/drivers/hwmon/emc2305.c
+index e0b7392..e1a21c7 100644
+--- a/drivers/hwmon/emc2305.c
++++ b/drivers/hwmon/emc2305.c
+@@ -18,7 +18,6 @@ static const unsigned short
+ emc2305_normal_i2c[] = { 0x27, 0x2c, 0x2d, 0x2e, 0x2f, 0x4c, 0x4d, I2C_CLIENT_END };
+ 
+ #define EMC2305_REG_DRIVE_FAIL_STATUS	0x27
+-#define EMC2305_REG_DEVICE		0xfd
+ #define EMC2305_REG_VENDOR		0xfe
+ #define EMC2305_FAN_MAX_NUM		5
+ #define EMC2305_FAN_MAX			0xff	/*100%*/
+@@ -432,7 +431,7 @@ static int emc2305_probe(struct i2c_client *client, const struct i2c_device_id *
+ 	struct device *dev = &client->dev;
+ 	u8 min_pwm, max_pwm, max_state;
+ 	struct emc2305_data *data;
+-	int vendor, device;
++	int vendor;
+ 	int ret;
+ 	int i;
+ 
+@@ -443,10 +442,6 @@ static int emc2305_probe(struct i2c_client *client, const struct i2c_device_id *
+ 	if (vendor != EMC2305_VENDOR)
+ 		return -ENODEV;
+ 
+-	device = i2c_smbus_read_byte_data(client, EMC2305_REG_DEVICE);
+-	if (device != EMC2305_DEVICE)
+-		return -ENODEV;
+-
+ 	max_state = EMC2305_FAN_MAX_STATE;
+ 	max_pwm = EMC2305_FAN_MAX;
+ 	min_pwm = EMC2305_FAN_MIN;
+-- 
+2.25.1
+

--- a/patch/series
+++ b/patch/series
@@ -180,6 +180,9 @@ cisco-Enable-static-memory-reservation-for-OIRable-PCIe-de.patch
 cisco-npu-disable-other-bars.patch
 cisco-hwmon-pmbus_core-pec-support-check.patch
 
+# Nokia patches for 5.10 kernel
+0001-hwmon-emc2305-Fix-unable-to-probe-emc2301-2-3.patch
+
 # sFlow + dropmon support
 0001-psample-Encapsulate-packet-metadata-in-a-struct.patch
 0002-psample-Add-additional-metadata-attributes.patch


### PR DESCRIPTION
The current code only supports EMC2305, enable support for EMC2301/2/3 also
Same driver is used for EMC 2301/2/3/5 family of products. 
https://docs.kernel.org/hwmon/emc2305.html

The definitions of 'EMC2305_REG_PRODUCT_ID' and 'EMC2305_REG_DEVICE' are
both '0xfd', they actually return the same value, but the values returned
by emc2301/2/3/5 are different, so probe emc2301/2/3 will fail, This patch
fixes that.

upstream commit:
https://github.com/torvalds/linux/commit/4d50591ebf60ccf79380fff3a4c23659c61c482f

Signed-off-by: Natarajan Subbiramani <natarajan.subbiramani.ext@nokia.com>
Signed-off-by: Xingjiang Qiao <nanpuyue@gmail.com>
Link: https://lore.kernel.org/r/20221206055331.170459-1-nanpuyue@gmail.com
Fixes: 0d8400c ("hwmon: (emc2305) add support for EMC2301/2/3/5 RPM-based PWM Fan Speed Controller.")
Signed-off-by: Guenter Roeck <linux@roeck-us.net>