### PR TITLE
Provision the ability to apply the non upstream patches in any order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,15 +65,14 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf $(NON_UP_DIR)
 	mkdir -p $(NON_UP_DIR)
 
-	if [ ! -z ${EXTERNAL_KERNEL_PATCH_URL} ];  then
-		wget $(EXTERNAL_KERNEL_PATCH_URL) -O patches.tar
-		tar -xf patches.tar -C $(NON_UP_DIR)
-	fi
-
-	# Precedence is given for external URL
-	if [ -z ${EXTERNAL_KERNEL_PATCH_URL} ] && [ x${INCLUDE_EXTERNAL_PATCHES} == xy ]; then
-		if [ -d "$(EXTERNAL_KERNEL_PATCH_LOC)" ]; then
-			cp -r $(EXTERNAL_KERNEL_PATCH_LOC)/* $(NON_UP_DIR)/
+	if [ x${INCLUDE_EXTERNAL_PATCHES} == xy ]; then
+		if [ ! -z ${EXTERNAL_KERNEL_PATCH_URL} ]; then
+			wget $(EXTERNAL_KERNEL_PATCH_URL) -O patches.tar
+			tar -xf patches.tar -C $(NON_UP_DIR)
+		else
+			if [ -d "$(EXTERNAL_KERNEL_PATCH_LOC)" ]; then
+				cp -r $(EXTERNAL_KERNEL_PATCH_LOC)/* $(NON_UP_DIR)/
+			fi
 		fi
 	fi
 


### PR DESCRIPTION
Currently, non upstream patches are applied only after upstream patches. 

**What i Did**

1) Apply a patch to the series files and copy the relevant patches into the patch/ folder
2) Non upstream Patches that reside in the sonic repo will not be saved in a tar file bur rather in a folder pointed out by `EXTERNAL_KERNEL_PATCH_LOC`. The build variable name is also updated to `INCLUDE_EXTERNAL_PATCHES` 
3) `INCLUDE_EXTERNAL_PATCHES` will be a mandatory parameter to include NON_UPSTREAM_PATCHES