### PR TITLE
Rename SECURE_UPGRADE_DEV_SIGNING_CERT to SECURE_UPGRADE_SIGNING_CERT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ KERNEL_SUBVERSION ?= 1
 kernel_procure_method ?= build
 CONFIGURED_ARCH ?= amd64
 SECURE_UPGRADE_MODE ?=
-SECURE_UPGRADE_DEV_SIGNING_CERT =?
+SECURE_UPGRADE_SIGNING_CERT =?
 
 LINUX_HEADER_COMMON = linux-headers-$(KVERSION_SHORT)-common_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION)_all.deb
 LINUX_HEADER_AMD64 = linux-headers-$(KVERSION)_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION)_$(CONFIGURED_ARCH).deb
@@ -125,7 +125,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	# Optionally add/remove kernel options
 	if [ -f ../manage-config ]; then
-		../manage-config $(CONFIGURED_ARCH) $(CONFIGURED_PLATFORM) $(SECURE_UPGRADE_MODE) $(SECURE_UPGRADE_DEV_SIGNING_CERT)
+		../manage-config $(CONFIGURED_ARCH) $(CONFIGURED_PLATFORM) $(SECURE_UPGRADE_MODE) $(SECURE_UPGRADE_SIGNING_CERT)
 	fi
 
 	# Building a custom kernel from Debian kernel source

--- a/manage-config
+++ b/manage-config
@@ -27,7 +27,7 @@
 ARCH=amd64
 PLATFORM=
 SECURE_UPGRADE_MODE="no_sign"
-SECURE_UPGRADE_DEV_SIGNING_CERT=
+SECURE_UPGRADE_SIGNING_CERT=
 if [ $# -ge 1 ]; then
     ARCH=$1
 fi
@@ -38,7 +38,7 @@ if [ $# -ge 3 ]; then
     SECURE_UPGRADE_MODE=$3
 fi
 if [ $# -ge 4 ]; then
-    SECURE_UPGRADE_DEV_SIGNING_CERT=$4
+    SECURE_UPGRADE_SIGNING_CERT=$4
 fi
 
 case "$ARCH" in
@@ -163,12 +163,12 @@ ret_process_inc_ex=$(process_inclusion_exclusion_files > /dev/null; echo $?)
 
 #  Secure Boot support
 if [ $ret_process_inc_ex -eq 0 ]; then
-    echo "Secure Boot params: SECURE_UPGRADE_MODE=${SECURE_UPGRADE_MODE}, SECURE_UPGRADE_DEV_SIGNING_CERT=${SECURE_UPGRADE_DEV_SIGNING_CERT}"
+    echo "Secure Boot params: SECURE_UPGRADE_MODE=${SECURE_UPGRADE_MODE}, SECURE_UPGRADE_SIGNING_CERT=${SECURE_UPGRADE_SIGNING_CERT}"
     if [ ${SECURE_UPGRADE_MODE} == "dev" -o ${SECURE_UPGRADE_MODE} == "prod" ]; then
         echo "set kconfig-secure-boot-exclusions & kconfig-secure-boot-inclusions"
 
-        if [ ! -f "${SECURE_UPGRADE_DEV_SIGNING_CERT}" ]; then
-            echo "ERROR: SECURE_UPGRADE_DEV_SIGNING_CERT=${SECURE_UPGRADE_DEV_SIGNING_CERT} file does not exist"
+        if [ ! -f "${SECURE_UPGRADE_SIGNING_CERT}" ]; then
+            echo "ERROR: SECURE_UPGRADE_SIGNING_CERT=${SECURE_UPGRADE_SIGNING_CERT} file does not exist"
             exit 1
         fi
 
@@ -177,7 +177,7 @@ if [ $ret_process_inc_ex -eq 0 ]; then
         force_inclusion_file="../patch/kconfig-force-secure-boot-inclusions"
 
         # save the new pub key in kernel
-        sed -i "s|^CONFIG_SYSTEM_TRUSTED_KEYS=.*|CONFIG_SYSTEM_TRUSTED_KEYS=\"$SECURE_UPGRADE_DEV_SIGNING_CERT\"|g" ${inclusion_file}
+        sed -i "s|^CONFIG_SYSTEM_TRUSTED_KEYS=.*|CONFIG_SYSTEM_TRUSTED_KEYS=\"$SECURE_UPGRADE_SIGNING_CERT\"|g" ${inclusion_file}
 
         ret_process_inc_ex=$(process_inclusion_exclusion_files > /dev/null; echo $?)
         echo "Secure Boot kernel configuration done."


### PR DESCRIPTION
The name SECURE_UPGRADE_DEV_SIGNING_CERT is misleading, this flag is relevant to both to dev and prod signing.

Rename all mentions of name SECURE_UPGRADE_DEV_SIGNING_CERT to SECURE_UPGRADE_SIGNING_CERT - this is also done with PR in sonic-buildimage repository - https://github.com/sonic-net/sonic-buildimage/pull/14591