### PR TITLE
Update codeowner and build info

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 # the repo. Unless a later match takes precedence,
 # @user will be requested for review when someone opens
 # a pull request.
-*       @sonic-kernel
+*       @sonic-net/sonic-linux-kernel-maintainer

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-[![Build Status](https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/linux-kernel-build/badge/icon)](https://sonic-jenkins.westus2.cloudapp.azure.com/job/common/job/linux-kernel-build/)
 
 # SONiC - Kernel
+
+## Build Status
+
+[![Master Branch](https://dev.azure.com/mssonic/build/_apis/build/status%2FAzure.sonic-linux-kernel?branchName=master&label=Master)](https://dev.azure.com/mssonic/build/_build/latest?definitionId=13&branchName=master)
+[![202211 Branch](https://dev.azure.com/mssonic/build/_apis/build/status%2FAzure.sonic-linux-kernel?branchName=202211&label=202211)](https://dev.azure.com/mssonic/build/_build/latest?definitionId=13&branchName=202211)
+[![202205 Branch](https://dev.azure.com/mssonic/build/_apis/build/status%2FAzure.sonic-linux-kernel?branchName=202205&label=202205)](https://dev.azure.com/mssonic/build/_build/latest?definitionId=13&branchName=202205)
 
 ## Description
 This repository contains the scripts and patches to build the kernel for SONiC. SONiC uses the same kernel for all platforms. We prefer to out-of-tree kernel platform modules. We accept kernel patches on following conditions:


### PR DESCRIPTION
Update the `CODEOWNERS` file to point to the current sonic-linux-kernel maintainers team. In addition, update the build badges in `README.md` to show the current build status.

In a future PR, I might add per-architecture build badges.