### PR TITLE
arm64: dts: marvell: Add DTS for 7215-IXS-A1 board

### DIFF
--- a/patch/0021-arm64-dts-marvell-Add-Nokia-7215-IXS-A1-board.patch
+++ b/patch/0021-arm64-dts-marvell-Add-Nokia-7215-IXS-A1-board.patch
@@ -1,133 +1,252 @@
-From 79de58e232cf5880a8ff68f15091febfc6c8fb3b Mon Sep 17 00:00:00 2001
+From d1cbdb3b1894c81f0762f3d7242c7f97a429de75 Mon Sep 17 00:00:00 2001
 From: Natarajan Subbiramani <natarajan.subbiramani.ext@nokia.com>
-Date: Tue, 13 Jun 2023 17:04:23 +0000
-Subject: [PATCH] arm64: dts: marvell: Add Nokia 7215-IXS-A1 board
+Date: Mon, 4 Mar 2024 14:22:19 -0500
+Subject: [PATCH] arm64: dts: marvell: Add DTS for 7215-IXS-A1 board
 
-This dts is derived from Marvell RD-AC5X board to 
-create platform specific dts for Nokia 7215-IXS-A1 
+7215-IXS-A1 is an aggregation switch based on Marvell AlleyCat5X.
+This dts is extracted from Marvell cn9130-crb and removed unused
+nodes along with platform specific changes.
 
 Signed-off-by: Natarajan Subbiramani <natarajan.subbiramani.ext@nokia.com>
 Tested-by:  Natarajan Subbiramani <natarajan.subbiramani.ext@nokia.com>
 Reviewed-by: Jon Goldberg <jon.goldberg@nokia.com>
 ---
- arch/arm64/boot/dts/marvell/7215-ixs-a1.dts | 108 ++++++++++++++++++++
+ arch/arm64/boot/dts/marvell/7215-ixs-a1.dts | 226 ++++++++++++++++++++
  arch/arm64/boot/dts/marvell/Makefile        |   1 +
- 2 files changed, 109 insertions(+)
+ 2 files changed, 227 insertions(+)
  create mode 100644 arch/arm64/boot/dts/marvell/7215-ixs-a1.dts
 
 diff --git a/arch/arm64/boot/dts/marvell/7215-ixs-a1.dts b/arch/arm64/boot/dts/marvell/7215-ixs-a1.dts
 new file mode 100644
-index 000000000..8c10c5415
+index 000000000000..e683b7ca4c9c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/marvell/7215-ixs-a1.dts
-@@ -0,0 +1,108 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+@@ -0,0 +1,226 @@
++// SPDX-License-Identifier: GPL-2.0+
 +/*
-+ * Copyright (C) 2023 Nokia
-+ * Copyright (C) 2021 Marvell
-+ * Copyright (C) 2022 Allied Telesis Labs
-+ */
-+/*
-+ * Device Tree file for Nokia 7215-IXS-A1
++ * Copyright (C) 2024 Nokia
++ * Copyright (C) 2020 Marvell International Ltd.
 + */
 +
-+/dts-v1/;
++#include "cn9130.dtsi" /* include SoC device tree */
 +
-+#include "ac5-98dx35xx.dtsi"
++#include <dt-bindings/gpio/gpio.h>
 +
 +/ {
-+	model = "7215-IXS-A1";
-+	compatible = "marvell,rd-ac5x", "marvell,ac5x", "marvell,ac5";
++	#address-cells = <0x02>;
++	#size-cells = <0x02>;
++	model = "7215 IXS-A1";
++	compatible = "marvell,cn9130\0marvell,armada-ap807-quad\0marvell,armada-ap807";
 +
 +	aliases {
-+		serial0 = &uart0;
-+		spiflash0 = &spiflash0;
-+		gpio0 = &gpio0;
-+		gpio1 = &gpio1;
-+		ethernet0 = &eth0;
-+		ethernet1 = &eth1;
++		i2c0 = &cp0_i2c0;
++		ethernet0 = &cp0_eth0;
++		ethernet1 = &cp0_eth1;
++		ethernet2 = &cp0_eth2;
++		gpio1 = &cp0_gpio1;
++		gpio2 = &cp0_gpio2;
 +	};
 +
 +	memory@0 {
 +		device_type = "memory";
-+		reg = <0x2 0x00000000 0x0 0x40000000>;
++		reg = <0x0 0x0 0x0 0x80000000>;
 +	};
 +
-+	usb1phy: usb-phy {
-+		compatible = "usb-nop-xceiv";
-+		#phy-cells = <0>;
-+	};
-+};
++	reserved-memory {
++		#address-cells = <0x02>;
++		#size-cells = <0x02>;
++		ranges;
 +
-+&mdio {
-+	phy0: ethernet-phy@0 {
-+		marvell,reg-init = <0x03 0x10 0x0 0x1140>;
-+		reg = <0>;
-+	};
-+};
++		/delete-node/ psci-area@4000000;
 +
-+&i2c0 {
-+	status = "okay";
-+};
-+
-+&i2c1 {
-+	status = "okay";
-+};
-+
-+&eth0 {
-+	status = "okay";
-+	phy-handle = <&phy0>;
-+};
-+
-+/* USB0 is a host USB */
-+&usb0 {
-+	status = "okay";
-+};
-+
-+/* USB1 is a peripheral USB */
-+&usb1 {
-+	status = "okay";
-+	phys = <&usb1phy>;
-+	phy-names = "usb-phy";
-+	dr_mode = "peripheral";
-+};
-+
-+&spi0 {
-+	status = "okay";
-+
-+	spiflash0: flash@0 {
-+		compatible = "jedec,spi-nor";
-+		spi-max-frequency = <50000000>;
-+		spi-tx-bus-width = <1>; /* 1-single, 2-dual, 4-quad */
-+		spi-rx-bus-width = <1>; /* 1-single, 2-dual, 4-quad */
-+		reg = <0>;
-+
-+		#address-cells = <1>;
-+		#size-cells = <1>;
-+
-+		partition@0 {
-+			label = "spi_flash_part0";
-+			reg = <0x0 0x800000>;
++		buf1: buffer@4000000 {
++			compatible = "shared-dma-pool";
++			reg = <0x0 0x04000000 0x0 0x02000000>;
++			no-map;
 +		};
-+
-+		parition@1 {
-+			label = "spi_flash_part1";
-+			reg = <0x800000 0x700000>;
-+		};
-+
-+		parition@2 {
-+			label = "spi_flash_part2";
-+			reg = <0xF00000 0x100000>;
++		psci-area@6000000 {
++			reg = <0x0 0x06000000 0x0 0x00200000>;
++			no-map;
 +		};
 +	};
-+};
 +
-+/{
-+	sdma_drv {
-+		compatible = "marvell,mvppnd";
-+		interrupts = <GIC_SPI 0x23 IRQ_TYPE_LEVEL_HIGH>;
++	mv_dma {
++		compatible = "marvell,mv_dma";
++		memory-region = <&buf1>;
 +		status = "okay";
 +	};
++
++	cp0_usb3_0_phy0: cp0_usb3_phy0 {
++		compatible = "usb-nop-xceiv";
++	};
++
++	cp0_usb3_0_phy1: cp0_usb3_phy1 {
++		compatible = "usb-nop-xceiv";
++	};
++};
++
++&cp0_syscon0 {
++	cp0_pinctrl: pinctrl {
++		compatible = "marvell,cp115-standalone-pinctrl";
++
++		cp0_i2c0_pins: cp0-i2c-pins-0 {
++			marvell,pins = "mpp37", "mpp38";
++			marvell,function = "i2c0";
++		};
++		cp0_i2c1_pins: cp0-i2c-pins-1 {
++			marvell,pins = "mpp35", "mpp36";
++			marvell,function = "i2c1";
++		};
++		cp0_spi0_pins: cp0-spi-pins-0 {
++			marvell,pins = "mpp13", "mpp14", "mpp15", "mpp16";
++			marvell,function = "spi1";
++		};
++	};
++};
++
++&cp0_gpio1 {
++	status = "okay";
++};
++
++&cp0_gpio2 {
++	status = "okay";
++};
++
++&cp0_pcie0 {
++	status = "okay";
++	num-lanes = <4>;
++	num-viewport = <8>;
++	/* Generic PHY, providing serdes lanes */
++	phys = <&cp0_comphy0 0
++		&cp0_comphy1 0
++		&cp0_comphy2 0
++		&cp0_comphy3 0>;
++	iommu-map =
++		<0x0   &smmu 0x480 0x20>,
++		<0x100 &smmu 0x4a0 0x20>,
++		<0x200 &smmu 0x4c0 0x20>;
++	iommu-map-mask = <0x031f>;
++};
++
++&uart0 {
++	status = "okay";
++};
++
++/* on-board eMMC U6 */
++&ap_sdhci0 {
++	pinctrl-names = "default";
++	bus-width = <8>;
++	status = "okay";
++	non-removable;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	mmc-hs400-1_8v;
++};
++
++/*Delete nodes that are not available*/
++/delete-node/ &cp0_rtc;
++/delete-node/ &cp0_sdhci0;
++/delete-node/ &cp0_crypto;
++
++&cp0_i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&cp0_i2c0_pins>;
++	status = "okay";
++	clock-frequency = <100000>;
++	rtc@68 {
++		compatible = "st,m41t11";
++		reg = <0x68>;
++	};
++};
++
++&cp0_i2c1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&cp0_i2c1_pins>;
++	clock-frequency = <100000>;
++	status = "okay";
++};
++
++&cp0_usb3_0 {
++	status = "okay";
++	usb-phy = <&cp0_usb3_0_phy0>;
++	phy-names = "usb";
++};
++
++&cp0_usb3_1 {
++	status = "okay";
++	usb-phy = <&cp0_usb3_0_phy1>;
++	phy-names = "usb";
++};
++
++&cp0_spi1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&cp0_spi0_pins>;
++	reg = <0x700680 0x50>,		/* control */
++	      <0x2000000 0x1000000>;	/* CS0 */
++	status = "okay";
++
++	flash@0 {
++		#address-cells = <0x1>;
++		#size-cells = <0x1>;
++		compatible = "jedec,spi-nor";
++		reg = <0x0>;
++		/* On-board MUX does not allow higher frequencies */
++		spi-max-frequency = <40000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "U-Boot";
++				reg = <0x0 0x2f0000>;
++			};
++
++			partition@1 {
++				label = "U-Boot-Env";
++				reg = <0x2f0000 0x10000>;
++			};
++
++			partition@2{
++				label = "Filesystem";
++				reg = <0x300000 0xd00000>;
++			};
++		};
++	};
++};
++
++&cp0_mdio {
++	status = "okay";
++	phy0: ethernet-phy@0 {
++		reg = <0>;
++		/* Management port LED blink activity*/
++		marvell,reg-init = <0x03 0x10 0x0 0x1140>;
++	};
++};
++
++&cp0_xmdio {
++	status = "disabled";
++};
++
++&cp0_ethernet {
++	status = "okay";
++};
++
++&cp0_eth0 {
++	status = "disabled";
++};
++
++&cp0_eth1 {
++	status = "disabled";
++};
++
++&cp0_eth2 {
++	/* This port uses "sgmii" phy-mode */
++	status = "okay";
++	phy = <&phy0>;
++	phys = <&cp0_comphy5 2>;
++	phy-mode = "sgmii";
 +};
 diff --git a/arch/arm64/boot/dts/marvell/Makefile b/arch/arm64/boot/dts/marvell/Makefile
 index 6873ad448..b53edc9b7 100644
@@ -138,6 +257,8 @@ index 6873ad448..b53edc9b7 100644
  dtb-$(CONFIG_ARCH_MVEBU) += ac5-98dx35xx-rd.dtb
  dtb-$(CONFIG_ARCH_MVEBU) += armada-7020-comexpress.dtb
 +dtb-$(CONFIG_ARCH_MVEBU) += 7215-ixs-a1.dtb
+
+base-commit: 6b6f1082cb46d72823b7ea99c058c601668ba1d3
 -- 
-2.25.1
+2.34.1
 


### PR DESCRIPTION
Create platform specific DTS for Marvell-arm64 based Nokia 7215-IXS-A1 platform.

7215-IXS-A1 is an aggregation switch based on Marvell AlleyCat5X. This DTS is extracted from Marvell cn9130-crb (reference board) and removed unused nodes along with platform specific changes.

This PR is a backport for PR #378 due to difference in patch file number between 5.10 and 6.1

Upstream Kernel PR
https://lore.kernel.org/linux-arm-kernel/CAJOx763HwgK-EEt-AkVqtoObhx_VGokj-Mn0yhS7Sno0uDOZfw@mail.gmail.com/T/#m3d1fc5bce0dcb5ec001f8496a207ccb485903507