### PR TITLE
Fix optoe's write_max when adapter supports i2c functions

### DIFF
--- a/patch/driver-support-optoe-write-max_fix.patch
+++ b/patch/driver-support-optoe-write-max_fix.patch
@@ -1,0 +1,35 @@
+From f1250392a9dff619b147d8aee0c73c0f6d550713 Mon Sep 17 00:00:00 2001
+From: Prince George <prgeor@microsoft.com>
+Date: Thu, 13 Jun 2024 14:18:22 +0000
+Subject: [PATCH] Fix optoe's write_max when using native i2c driver
+
+Signed-off-by: Prince George <prgeor@microsoft.com>
+---
+ drivers/misc/eeprom/optoe.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/misc/eeprom/optoe.c b/drivers/misc/eeprom/optoe.c
+index 5a2e71be5..1efd18040 100644
+--- a/drivers/misc/eeprom/optoe.c
++++ b/drivers/misc/eeprom/optoe.c
+@@ -1114,7 +1114,7 @@ static int optoe_probe(struct i2c_client *client,
+ 		goto exit;
+ 	}
+ 
+-	dev_dbg(&client->dev, "dev_class: %d\n", optoe->dev_class);
++	dev_dbg(&client->dev, "dev_class: %d use_smbus=%d\n", optoe->dev_class, use_smbus);
+ 	optoe->use_smbus = use_smbus;
+ 	optoe->chip = chip;
+ 	optoe->num_addresses = num_addresses;
+@@ -1157,7 +1157,7 @@ static int optoe_probe(struct i2c_client *client,
+ 		optoe->write_max = write_max;
+ 
+ 		/* buffer (data + address at the beginning) */
+-		optoe->writebuf = kmalloc(write_max + 2, GFP_KERNEL);
++		optoe->writebuf = kmalloc(OPTOE_PAGE_SIZE + 2, GFP_KERNEL);
+ 		if (!optoe->writebuf) {
+ 			err = -ENOMEM;
+ 			goto exit_kfree;
+-- 
+2.25.1
+

--- a/patch/series
+++ b/patch/series
@@ -29,6 +29,7 @@ driver-support-optoe-EOF_fix.patch
 driver-support-optoe-chunk-offset-fix.patch
 driver-support-optoe-QSFP_DD.patch
 driver-support-optoe-write-max.patch
+driver-support-optoe-write-max_fix.patch
 driver-support-optoe-twoaddr-a2h-access.patch
 driver-support-optoe-oneaddr-pageable.patch
 driver-support-optoe-dynamic-write-timeout.patch


### PR DESCRIPTION
Optoe driver with write-max > 1 when using the i2c message buffer was allocating only 3(1+2) bytes  which means while copying the user data for i2c adapters supporting the native i2c functions will overwrite the message buffer size. This will not happen for i2c adapters that does not support native i2c functions like pure SMBUS controller.