### PR TITLE
Disable AMD memory encryption

### DIFF
--- a/patch/kconfig-exclusions
+++ b/patch/kconfig-exclusions
@@ -12,6 +12,7 @@ CONFIG_MTD_SPI_NOR_USE_4K_SECTORS
 ###-> mellanox_common-end
 
 [amd64]
+CONFIG_AMD_MEM_ENCRYPT
 # Unset X86_PAT according to Broadcom's requirement
 CONFIG_X86_PAT
 CONFIG_MLXSW_PCI


### PR DESCRIPTION
Under some specific circumstances, having memory encryption turned on lead to silent kernel crashes.
This is currently preventing SONiC using linux 6.1+ from being kexec'ed from Aboot uing kexec-tools in 64 bit.

Bisecting the kernel code pointed the following change as the culprit
[c01fce9cef8491974f7f007f90281f1608400768] x86/compressed: Add SEV-SNP feature detection/setup