### PR TITLE
[202405] Fix for Winbond flash devices that could not parse SFDP

### DIFF
--- a/patch/0001-Revert-mtd-spi-nor-Correct-flags-for-Winbond-w25q128.patch
+++ b/patch/0001-Revert-mtd-spi-nor-Correct-flags-for-Winbond-w25q128.patch
@@ -1,0 +1,29 @@
+From 29922c1e20e86e643687a76b8c3181e388067b03 Mon Sep 17 00:00:00 2001
+From: Vivek Reddy <vkarri@nvidia.com>
+Date: Fri, 27 Sep 2024 02:27:37 +0000
+Subject: [PATCH] Revert "mtd: spi-nor: Correct flags for Winbond w25q128"
+
+This reverts commit 7c6ba20a0b9aeb82a6c097c74ccbecdda8e9fc25.
+---
+ drivers/mtd/spi-nor/winbond.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/mtd/spi-nor/winbond.c b/drivers/mtd/spi-nor/winbond.c
+index b7c775b615e8..ffaa24055259 100644
+--- a/drivers/mtd/spi-nor/winbond.c
++++ b/drivers/mtd/spi-nor/winbond.c
+@@ -120,9 +120,8 @@ static const struct flash_info winbond_nor_parts[] = {
+ 		NO_SFDP_FLAGS(SECT_4K) },
+ 	{ "w25q80bl", INFO(0xef4014, 0, 64 * 1024,  16)
+ 		NO_SFDP_FLAGS(SECT_4K) },
+-	{ "w25q128", INFO(0xef4018, 0, 0, 0)
+-		PARSE_SFDP
+-		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
++	{ "w25q128", INFO(0xef4018, 0, 64 * 1024, 256)
++		NO_SFDP_FLAGS(SECT_4K) },
+ 	{ "w25q256", INFO(0xef4019, 0, 64 * 1024, 512)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ)
+ 		.fixups = &w25q256_fixups },
+-- 
+2.43.2
+

--- a/patch/series
+++ b/patch/series
@@ -210,6 +210,9 @@ cisco-npu-disable-other-bars.patch
 0028-Create-miniaturised-diafgw-partition-for-128MB-flash.patch
 0029-pcie-if-hotplug-enabled-do-immediate-reset-on-panic.patch
 
+# Fix for w25q128 flash that dont have SFDP support
+0001-Revert-mtd-spi-nor-Correct-flags-for-Winbond-w25q128.patch 
+
 # Security patch
 0001-Change-the-system.map-file-permission-only-readable-.patch
 


### PR DESCRIPTION
Backport https://github.com/sonic-net/sonic-linux-kernel/pull/436 to 202405