### PR TITLE
[202405][PCI/ASPM] Revert commit `456d8aa` to avoid kernel panics in `6.1.94`

### DIFF
--- a/patch/revert-456d8aa-to-fix-pcie_aspm_exit_link_status.patch
+++ b/patch/revert-456d8aa-to-fix-pcie_aspm_exit_link_status.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nathan Wolfe <nwolfe@arista.com>
+Date: Tue, 8 Oct 2024 11:57:26 -0700
+Subject: [PATCH] revert 456d8aa to fix pcie_aspm_exit_link_status
+
+For certain pci tree structures involving pci devices with sibling
+functions we can get a nullptr dereference when the link state goes down
+due to this change.
+
+https://github.com/torvalds/linux/commit/456d8aa37d0f56fc9e985e812496e861dcd6f2f2
+Upstream Discussion:
+https://lore.kernel.org/linux-pci/20240801171103.GA107989@bhelgaas/T/#t
+---
+ drivers/pci/pcie/aspm.c | 21 +++++++++------------
+ 1 file changed, 9 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/pci/pcie/aspm.c b/drivers/pci/pcie/aspm.c
+index cf4acea66..188517c5a 100644
+--- a/drivers/pci/pcie/aspm.c
++++ b/drivers/pci/pcie/aspm.c
+@@ -1025,24 +1025,21 @@ void pcie_aspm_exit_link_state(struct pci_dev *pdev)
+ 
+ 	down_read(&pci_bus_sem);
+ 	mutex_lock(&aspm_lock);
++	/*
++	 * All PCIe functions are in one slot, remove one function will remove
++	 * the whole slot, so just wait until we are the last function left.
++	 */
++	if (!list_empty(&parent->subordinate->devices))
++		goto out;
+ 
+ 	link = parent->link_state;
+ 	root = link->root;
+ 	parent_link = link->parent;
+ 
+-	/*
+-	 * link->downstream is a pointer to the pci_dev of function 0.  If
+-	 * we remove that function, the pci_dev is about to be deallocated,
+-	 * so we can't use link->downstream again.  Free the link state to
+-	 * avoid this.
+-	 *
+-	 * If we're removing a non-0 function, it's possible we could
+-	 * retain the link state, but PCIe r6.0, sec 7.5.3.7, recommends
+-	 * programming the same ASPM Control value for all functions of
+-	 * multi-function devices, so disable ASPM for all of them.
+-	 */
++	/* All functions are removed, so just disable ASPM for the link */
+ 	pcie_config_aspm_link(link, 0);
+ 	list_del(&link->sibling);
++	/* Clock PM is for endpoint device */
+ 	free_link_state(link);
+ 
+ 	/* Recheck latencies and configure upstream links */
+@@ -1050,7 +1047,7 @@ void pcie_aspm_exit_link_state(struct pci_dev *pdev)
+ 		pcie_update_aspm_capable(root);
+ 		pcie_config_aspm_path(parent_link);
+ 	}
+-
++out:
+ 	mutex_unlock(&aspm_lock);
+ 	up_read(&pci_bus_sem);
+ }

--- a/patch/series
+++ b/patch/series
@@ -219,6 +219,10 @@ cisco-npu-disable-other-bars.patch
 # Security patch
 0001-Change-the-system.map-file-permission-only-readable-.patch
 
+# Fix to avoid kernel panic on Kernel 6.1.94
+# https://github.com/sonic-net/sonic-buildimage/issues/20901
+revert-456d8aa-to-fix-pcie_aspm_exit_link_status.patch
+
 #
 #
 ############################################################


### PR DESCRIPTION
Manual cherry-pick of https://github.com/sonic-net/sonic-linux-kernel/pull/448 to the 202405 branch.

* Reverting 456d8aa to avoid kernel panics in 6.1.94

For certain pci tree structures involving pci devices with sibling functions we can get a nullptr dereference when the link state goes down due to this change.

Fixing: https://github.com/sonic-net/sonic-buildimage/issues/20901 
Reverting: https://github.com/torvalds/linux/commit/456d8aa37d0f56fc9e985e812496e861dcd6f2f2 
Upstream Discussion: https://lore.kernel.org/linux-pci/20240801171103.GA107989@bhelgaas/T/#t

* Adding upstream discussion link and summary in patch