### PR TITLE
[optoe] Reset page select byte to 0 before upper memory access on page 0h

### DIFF
--- a/patch/driver-support-optoe-non-sfp-reset-page-select.patch
+++ b/patch/driver-support-optoe-non-sfp-reset-page-select.patch
@@ -33,19 +33,27 @@ The fix has been tested on a non-SFP module and it was ensured that the sfputil 
 
 Signed-off-by: Mihir Patel <patelmi@microsoft.com>
 ---
- drivers/misc/eeprom/optoe.c | 13 +++++++++++++
- 1 file changed, 13 insertions(+)
+ drivers/misc/eeprom/optoe.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
 
 diff --git a/drivers/misc/eeprom/optoe.c b/drivers/misc/eeprom/optoe.c
-index 22d2c0cd4..f3f9d89c4 100644
+index 22d2c0cd4..2ffcb23e9 100644
 --- a/drivers/misc/eeprom/optoe.c
 +++ b/drivers/misc/eeprom/optoe.c
-@@ -528,6 +528,19 @@ static ssize_t optoe_eeprom_update_client(struct optoe_data *optoe,
+@@ -528,6 +528,27 @@ static ssize_t optoe_eeprom_update_client(struct optoe_data *optoe,
  					page, ret);
  			return ret;
  		}
 +	} else {
-+		/* Set the page select byte to 0 if accessing the upper memory of page 0h (limit scope of fix to non-SFP modules) */
++		/*
++		 * Reset page select byte to 0 when accessing upper memory (offset >= 128) of page 0h.
++		 * This is only done for non-SFP modules because:
++		 * 1. SFP modules have page select byte on A2h address (0x51), not A0h (0x50) unlike
++		 *     non-SFP modules (QSFP, CMIS). This mandates additional handling for SFP modules.
++		 * 3. SFPs requiring page select changes are uncommon, so this fix targets non-SFP modules only
++		 *
++		 * Note: This fix can be enhanced in the future to support SFP modules if needed.
++		 */
 +		if (optoe->dev_class != TWO_ADDR && phy_offset >= OPTOE_PAGE_SIZE) {
 +			page = 0;
 +			ret = optoe_eeprom_write(optoe, client, &page,

--- a/patch/driver-support-optoe-non-sfp-reset-page-select.patch
+++ b/patch/driver-support-optoe-non-sfp-reset-page-select.patch
@@ -51,7 +51,7 @@ index 22d2c0cd4..f3f9d89c4 100644
 +			ret = optoe_eeprom_write(optoe, client, &page,
 +				OPTOE_PAGE_SELECT_REG, 1);
 +			if (ret < 0) {
-+				dev_warn(&client->dev,
++				dev_err(&client->dev,
 +					"Non-SFP write page register for page %d failed ret:%d!\n",
 +						page, ret);
 +				return ret;

--- a/patch/driver-support-optoe-non-sfp-reset-page-select.patch
+++ b/patch/driver-support-optoe-non-sfp-reset-page-select.patch
@@ -51,7 +51,7 @@ index 22d2c0cd4..f3f9d89c4 100644
 +			ret = optoe_eeprom_write(optoe, client, &page,
 +				OPTOE_PAGE_SELECT_REG, 1);
 +			if (ret < 0) {
-+				dev_err(&client->dev,
++				dev_warn(&client->dev,
 +					"Non-SFP write page register for page %d failed ret:%d!\n",
 +						page, ret);
 +				return ret;

--- a/patch/driver-support-optoe-non-sfp-reset-page-select.patch
+++ b/patch/driver-support-optoe-non-sfp-reset-page-select.patch
@@ -1,0 +1,65 @@
+From 719486dda84c1f058b24916dc386888cbb6ac1ee Mon Sep 17 00:00:00 2001
+From: Mihir Patel <patelmi@microsoft.com>
+Date: Wed, 12 Feb 2025 21:04:48 +0000
+Subject: [PATCH] Reset page select byte to 0
+
+Description
+The optoe kernel driver currently assumes that the page select byte (page 0, byte 127) is set to 0h before accessing the upper memory on page 0h.
+This assumption causes failures when accessing the module's EEPROM in multiple scenarios.
+On the contrary, the driver currently sets the page select byte if the intended page to be accessed is > 0 as evident from the below code
+https://github.com/opencomputeproject/oom/blob/c32499a89dff005e7ff2acb48b33f55543ce5140/optoe/optoe.c#L344-L353
+
+Impact
+If the optoe driver accesses any page except page 0h and the code for restoring the page select byte to 0h fails, subsequent attempts to
+access the upper memory of page 0h will fail because the page select byte from the previous transaction remains unchanged.
+https://github.com/opencomputeproject/oom/blob/c32499a89dff005e7ff2acb48b33f55543ce5140/optoe/optoe.c#L373-L392
+
+Steps to recreate the failure scenario
+One way to recreate this issue is:
+
+1. Initiate CDB firmware download operation on a module supporting CDB foreground mode only
+2. Kill the process which is downloading the FW
+3. Dump the page select byte and ensure it displays a non-zero value
+4. Execute sfputil show fwversion EthernetXX CLI and you will observe a traceback. The traceback occurs because the vendor name is read
+with garbage content, as the page select byte is set to 0x9F instead of 0x0.
+
+Fix
+Before optoe accesses any address from upper page 0h, the page select byte is now set to 0.
+This fix is done only for non-SFP modules to limit the scope of impact. SFP modules require additional handling since the page select byte
+is on page A2h and NOT A0h unlike non-SFP modules which do not have the concept of A0h and A2h page.
+
+Testing
+The fix has been tested on a non-SFP module and it was ensured that the sfputil show fwversion EthernetXX CLI command executes successfully without any traceback.
+
+Signed-off-by: Mihir Patel <patelmi@microsoft.com>
+---
+ drivers/misc/eeprom/optoe.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/drivers/misc/eeprom/optoe.c b/drivers/misc/eeprom/optoe.c
+index 22d2c0cd4..f3f9d89c4 100644
+--- a/drivers/misc/eeprom/optoe.c
++++ b/drivers/misc/eeprom/optoe.c
+@@ -528,6 +528,19 @@ static ssize_t optoe_eeprom_update_client(struct optoe_data *optoe,
+ 					page, ret);
+ 			return ret;
+ 		}
++	} else {
++		/* Set the page select byte to 0 if accessing the upper memory of page 0h (limit scope of fix to non-SFP modules) */
++		if (optoe->dev_class != TWO_ADDR && phy_offset >= OPTOE_PAGE_SIZE) {
++			page = 0;
++			ret = optoe_eeprom_write(optoe, client, &page,
++				OPTOE_PAGE_SELECT_REG, 1);
++			if (ret < 0) {
++				dev_err(&client->dev,
++					"Non-SFP write page register for page %d failed ret:%d!\n",
++						page, ret);
++				return ret;
++			}
++		}
+ 	}
+ 
+ 	while (count) {
+-- 
+2.25.1
+

--- a/patch/series
+++ b/patch/series
@@ -34,6 +34,7 @@ driver-support-optoe-twoaddr-a2h-access.patch
 driver-support-optoe-oneaddr-pageable.patch
 driver-support-optoe-update-to-linux-6.1.patch
 driver-support-optoe-dynamic-write-timeout.patch
+driver-support-optoe-non-sfp-reset-page-select.patch
 driver-net-tg3-add-param-short-preamble-and-reset.patch
 driver-net-tg3-change-dma-mask-for-57766.patch
 0004-dt-bindings-hwmon-Add-missing-documentation-for-lm75.patch


### PR DESCRIPTION
**Description**
The optoe kernel driver currently assumes that the page select byte (page 0, byte 127) is set to 0h before accessing the upper memory on page 0h.
This assumption causes failures when accessing the module's EEPROM in multiple scenarios.
On the contrary, the driver currently sets the page select byte if the intended page to be accessed is > 0 as evident from the below code
https://github.com/opencomputeproject/oom/blob/c32499a89dff005e7ff2acb48b33f55543ce5140/optoe/optoe.c#L344-L353

**Impact**
If the optoe driver accesses any page except page 0h and the code for restoring the page select byte to 0h fails, subsequent attempts to
access the upper memory of page 0h will fail because the page select byte from the previous transaction remains unchanged.
https://github.com/opencomputeproject/oom/blob/c32499a89dff005e7ff2acb48b33f55543ce5140/optoe/optoe.c#L373-L392

**Steps to recreate the failure scenario**
One way to recreate this issue is:

1. Initiate CDB firmware download operation on a module supporting CDB foreground mode only
2. Kill the process which is downloading the FW
3. Dump the page select byte and ensure it displays a non-zero value
4. Execute sfputil show fwversion EthernetXX CLI and you will observe a traceback. The traceback occurs because the vendor name is read
with garbage content, as the page select byte is set to 0x9F instead of 0x0.

**Fix**
Before optoe accesses any address from upper page 0h, the page select byte is now set to 0.
This fix is done only for non-SFP modules to limit the scope of impact. SFP modules require additional handling since the page select byte
is on page A2h and NOT A0h unlike non-SFP modules which do not have the concept of A0h and A2h page.

**Testing**
The fix has been tested on a non-SFP module and it was ensured that the sfputil show fwversion EthernetXX CLI command executes successfully without any traceback.

**Logs for testing the fix**
```
root@dut:/home/admin# sfputil firmware download Ethernet496 FIRMWARE_FILE.bin
CDB: Starting firmware download
Downloading ...  [#-----------------------------------]    4%  00:08:07^C

Aborted!
root@dut:/home/admin#  i2cget -f -y 103 0x50 0x7f
0x9f
root@dut:/home/admin# sfputil show fwversion Ethernet496
Image A Version: 1.2.3
Image B Version: N/A
Factory Image Version: 0.0.0
Running Image: A
Committed Image: A
Active Firmware: 1.2.3
Inactive Firmware: 170.170.0

root@dut:/home/admin# 
```

**Logs for the failure scenario**
```
Initiate CDB firmware download operation on a module supporting CDB foreground mode only
Kill the process which is downloading the FW
root@dut:/home/admin# sfputil firmware download Ethernet496 FIRMWARE_FILE.bin
CDB: Starting firmware download
Downloading ...  [##----------------------------------]    6%  00:07:57^C

Aborted!
root@dut:/home/admin#

Dump the page select byte and ensure it displays a non-zero value
root@dut:/home/admin#  i2cget -f -y 103 0x50 0x7f
0x9f

Execute sfputil show fwversion EthernetXX CLI and you will observe a traceback. The traceback is seen since the vendor name is being read with garbage content since the page select byte is set to 0x9F and NOT 0x0.

root@dut:/home/admin# sfputil show fwversion Ethernet496
Traceback (most recent call last):
  File "/usr/local/bin/sfputil", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/sfputil/main.py", line 1215, in fwversion
    show_firmware_version(physical_port)
  File "/usr/local/lib/python3.11/dist-packages/sfputil/main.py", line 1185, in show_firmware_version
    api = sfp.get_xcvr_api()
          ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/sonic_platform_base/sfp_base.py", line 480, in get_xcvr_api
    self.refresh_xcvr_api()
  File "/usr/local/lib/python3.11/dist-packages/sonic_platform_base/sfp_base.py", line 470, in refresh_xcvr_api
    self._xcvr_api = self._xcvr_api_factory.create_xcvr_api()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py", line 79, in create_xcvr_api
    vendor_name = self._get_vendor_name()
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py", line 64, in _get_vendor_name
    vendor_name = name_data.decode()
                  ^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 2: invalid start byte

Invalid vendor name content:
80: 01 04 00 80 04 ff 00 00 00 00 77 00 00 00 00 00    ??.??.....w.....
90: 49
```

MSFT ADO - 31376026

Signed-off-by: Mihir Patel <patelmi@microsoft.com>