### PR TITLE
Fix error for writing page select register on certain xcvrs

### DIFF
--- a/patch/driver-support-optoe-non-sfp-reset-page-select.patch
+++ b/patch/driver-support-optoe-non-sfp-reset-page-select.patch
@@ -40,7 +40,7 @@ diff --git a/drivers/misc/eeprom/optoe.c b/drivers/misc/eeprom/optoe.c
 index 22d2c0cd4..2ffcb23e9 100644
 --- a/drivers/misc/eeprom/optoe.c
 +++ b/drivers/misc/eeprom/optoe.c
-@@ -528,6 +528,27 @@ static ssize_t optoe_eeprom_update_client(struct optoe_data *optoe,
+@@ -528,6 +528,36 @@ static ssize_t optoe_eeprom_update_client(struct optoe_data *optoe,
  					page, ret);
  			return ret;
  		}
@@ -55,14 +55,23 @@ index 22d2c0cd4..2ffcb23e9 100644
 +		 * Note: This fix can be enhanced in the future to support SFP modules if needed.
 +		 */
 +		if (optoe->dev_class != TWO_ADDR && phy_offset >= OPTOE_PAGE_SIZE) {
-+			page = 0;
-+			ret = optoe_eeprom_write(optoe, client, &page,
++			ret = optoe_eeprom_read(optoe, client, &page,
 +				OPTOE_PAGE_SELECT_REG, 1);
 +			if (ret < 0) {
 +				dev_err(&client->dev,
-+					"Non-SFP write page register for page %d failed ret:%d!\n",
-+						page, ret);
++					"Non-SFP read page register failed ret:%d!\n", ret);
 +				return ret;
++			}
++			if (page != 0) {
++				page = 0;
++				ret = optoe_eeprom_write(optoe, client, &page,
++					OPTOE_PAGE_SELECT_REG, 1);
++				if (ret < 0) {
++					dev_err(&client->dev,
++						"Non-SFP write page register for page %d failed ret:%d!\n",
++							page, ret);
++					return ret;
++				}
 +			}
 +		}
  	}


### PR DESCRIPTION
On Arista platforms, we see the error like below for certain type of xcvrs.
WARNING kernel: [13095.179904] scd 0000:03:00.0: #3 rsp { .reg=0x00002400, .fe=0, .foe=0, .ss=00, .ti=02, .flushed=0, .ack_error=1, .timeout_error=0, .bus_conflict_error=0, .d=0x00 } bus=41 addr=0x50 ti=2 err=-5 
ERR kernel: [13095.181197] optoe 41-0050: Non-SFP write page register for page 0 failed ret:-110!

The patch writes page select register to 0 always. However, certain type of xcvrs is not responding to it resulting in errors. The workaround here is to only write it to 0 when the existing value is not 0.