### PR TITLE
Fix for i2c_designware shutdown

### DIFF
--- a/patch/driver-arista-i2c-designware-shutdown.patch
+++ b/patch/driver-arista-i2c-designware-shutdown.patch
@@ -1,0 +1,49 @@
+From: Justin Oliver <justinoliver@arista.com>
+Date: 2022-12-12 17:42:20 +0000
+Subject: Designware I2C driver fails to probe device after kexec
+
+The Designware I2C driver sometimes fails to probe the I2C controller after
+we boot into another kernel with kexec. Kexec will call the `shutdown`
+method of each platform driver before booting the new kernel so this patch
+defines a `shutdown` procedure for the Designware I2C platform driver. This
+will gracefully bring down the I2C controller, allowing the driver to
+successfully initialize the device with the new kernel.
+
+---
+ drivers/i2c/busses/i2c-designware-platdrv.c |   16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/drivers/i2c/busses/i2c-designware-platdrv.c b/drivers/i2c/busses/i2c-designware-platdrv.c
+index 01234567..89abcdef 100644
+--- a/drivers/i2c/busses/i2c-designware-platdrv.c
++++ b/drivers/i2c/busses/i2c-designware-platdrv.c
+@@ -350,6 +350,21 @@ static int dw_i2c_plat_remove(struct platform_device *pdev)
+ 	return 0;
+ }
+ 
++static void dw_i2c_plat_shutdown(struct platform_device *pdev)
++{
++	struct dw_i2c_dev *dev = platform_get_drvdata(pdev);
++
++	pm_runtime_get_sync(&pdev->dev);
++
++	dev->disable(dev);
++
++	pm_runtime_dont_use_autosuspend(&pdev->dev);
++	pm_runtime_put_sync(&pdev->dev);
++	dw_i2c_plat_pm_cleanup(dev);
++
++	reset_control_assert(dev->rst);
++}
++
+ #ifdef CONFIG_PM_SLEEP
+ static int dw_i2c_plat_prepare(struct device *dev)
+ {
+@@ -425,6 +440,7 @@ MODULE_ALIAS("platform:i2c_designware");
+ static struct platform_driver dw_i2c_driver = {
+ 	.probe = dw_i2c_plat_probe,
+ 	.remove = dw_i2c_plat_remove,
++	.shutdown = dw_i2c_plat_shutdown,
+ 	.driver		= {
+ 		.name	= "i2c_designware",
+ 		.of_match_table = of_match_ptr(dw_i2c_of_match),

--- a/patch/series
+++ b/patch/series
@@ -10,6 +10,7 @@ driver-arista-net-tg3-access-regs-indirectly.patch
 driver-arista-pci-reassign-pref-mem.patch
 driver-arista-mmcblk-not-working-on-AMD-platforms.patch
 driver-arista-restrict-eMMC-drive-to-50Mhz-from-userland.patch
+driver-arista-i2c-designware-shutdown.patch
 driver-support-sff-8436-eeprom.patch
 driver-support-sff-8436-eeprom-update.patch
 driver-sff-8436-use-nvmem-framework.patch


### PR DESCRIPTION
Designware I2C driver was failing to probe the I2C controller after we kexec to another kernel on some Arista platforms:
i2c_designware AMDI0010:00: Unknown Synopsys component type: 0xffffffff