### PR TITLE
Ignore table if the EFI memory attributes are corrupt

### DIFF
--- a/patch/0001-efi-memattr-Ignore-table-if-the-size-is-clearly-bogus.patch
+++ b/patch/0001-efi-memattr-Ignore-table-if-the-size-is-clearly-bogus.patch
@@ -1,0 +1,66 @@
+From 8fbe4c49c0ccac9a6a3cff35a45fa55d4ae35d6e Mon Sep 17 00:00:00 2001
+From: Ard Biesheuvel <ardb@kernel.org>
+Date: Thu, 31 Oct 2024 18:58:23 +0100
+Subject: [PATCH] efi/memattr: Ignore table if the size is clearly bogus
+
+There are reports [0] of cases where a corrupt EFI Memory Attributes
+Table leads to out of memory issues at boot because the descriptor size
+and entry count in the table header are still used to reserve the entire
+table in memory, even though the resulting region is gigabytes in size.
+
+Given that the EFI Memory Attributes Table is supposed to carry up to 3
+entries for each EfiRuntimeServicesCode region in the EFI memory map,
+and given that there is no reason for the descriptor size used in the
+table to exceed the one used in the EFI memory map, 3x the size of the
+entire EFI memory map is a reasonable upper bound for the size of this
+table. This means that sizes exceeding that are highly likely to be
+based on corrupted data, and the table should just be ignored instead.
+
+[0] https://bugzilla.suse.com/show_bug.cgi?id=1231465
+
+Cc: Gregory Price <gourry@gourry.net>
+Cc: Usama Arif <usamaarif642@gmail.com>
+Acked-by: Jiri Slaby <jirislaby@kernel.org>
+Acked-by: Breno Leitao <leitao@debian.org>
+Link: https://lore.kernel.org/all/20240912155159.1951792-2-ardb+git@google.com/
+Signed-off-by: Ard Biesheuvel <ardb@kernel.org>
+---
+ drivers/firmware/efi/memattr.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/firmware/efi/memattr.c b/drivers/firmware/efi/memattr.c
+index 164203429fa7a3..c38b1a335590d4 100644
+--- a/drivers/firmware/efi/memattr.c
++++ b/drivers/firmware/efi/memattr.c
+@@ -22,6 +22,7 @@ unsigned long __ro_after_init efi_mem_attr_table = EFI_INVALID_TABLE_ADDR;
+ int __init efi_memattr_init(void)
+ {
+ 	efi_memory_attributes_table_t *tbl;
++	unsigned long size;
+ 
+ 	if (efi_mem_attr_table == EFI_INVALID_TABLE_ADDR)
+ 		return 0;
+@@ -39,7 +40,22 @@ int __init efi_memattr_init(void)
+ 		goto unmap;
+ 	}
+ 
+-	tbl_size = sizeof(*tbl) + tbl->num_entries * tbl->desc_size;
++
++	/*
++	 * Sanity check: the Memory Attributes Table contains up to 3 entries
++	 * for each entry of type EfiRuntimeServicesCode in the EFI memory map.
++	 * So if the size of the table exceeds 3x the size of the entire EFI
++	 * memory map, there is clearly something wrong, and the table should
++	 * just be ignored altogether.
++	 */
++	size = tbl->num_entries * tbl->desc_size;
++	if (size > 3 * efi.memmap.nr_map * efi.memmap.desc_size) {
++		pr_warn(FW_BUG "Corrupted EFI Memory Attributes Table detected! (version == %u, desc_size == %u, num_entries == %u)\n",
++			tbl->version, tbl->desc_size, tbl->num_entries);
++		goto unmap;
++	}
++
++	tbl_size = sizeof(*tbl) + size;
+ 	memblock_reserve(efi_mem_attr_table, tbl_size);
+ 	set_bit(EFI_MEM_ATTR, &efi.flags);
+ 

--- a/patch/series
+++ b/patch/series
@@ -69,6 +69,8 @@ Support-for-fullcone-nat.patch
 # Tbridge-per-port-multicast-broadcast-flood-flags.patch
 #
 
+0001-efi-memattr-Ignore-table-if-the-size-is-clearly-bogus.patch
+
 # Mellanox patches for 5.10
 ###-> mellanox_sdk-start
 0001-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch


### PR DESCRIPTION
Backport https://github.com/torvalds/linux/commit/8fbe4c49c0ccac9a6a3cff35a45fa55d4ae35d6e into sonic kernel.

On one of our platforms, we sporadically seeing this kernel error log after a reboot

```
2025 Jul  8 15:05:16.109392 sonic ERR kernel: [    0.121956] efi: memattr: Failed to map EFI Memory Attributes table @ 0xb4ad7118
```

This error log is hard to reproduce, has no functional impact and is also seen in upstream devices as explained the description above.  However, the RC of why this is happening is still unknown. 

Thus backporting this commit to print more info and change the verbosity to WARN