### PR TITLE
Add upstream fix for bridge link show failure

### DIFF
--- a/patch/0001-prevent-bridge-link-show-failure-for-non-eswitch-allowed-devices.patch
+++ b/patch/0001-prevent-bridge-link-show-failure-for-non-eswitch-allowed-devices.patch
@@ -1,0 +1,45 @@
+From e92df790d07a8eea873efcb84776e7b71f81c7d5 Mon Sep 17 00:00:00 2001
+From: Carolina Jubran <cjubran@nvidia.com>
+Date: Tue, 11 Mar 2025 00:01:44 +0200
+Subject: [PATCH] net/mlx5e: Prevent bridge link show failure for
+ non-eswitch-allowed devices
+
+mlx5_eswitch_get_vepa returns -EPERM if the device lacks
+eswitch_manager capability, blocking mlx5e_bridge_getlink from
+retrieving VEPA mode. Since mlx5e_bridge_getlink implements
+ndo_bridge_getlink, returning -EPERM causes bridge link show to fail
+instead of skipping devices without this capability.
+
+To avoid this, return -EOPNOTSUPP from mlx5e_bridge_getlink when
+mlx5_eswitch_get_vepa fails, ensuring the command continues processing
+other devices while ignoring those without the necessary capability.
+
+Fixes: 4b89251de024 ("net/mlx5: Support ndo bridge_setlink and getlink")
+Signed-off-by: Carolina Jubran <cjubran@nvidia.com>
+Reviewed-by: Jianbo Liu <jianbol@nvidia.com>
+Signed-off-by: Tariq Toukan <tariqt@nvidia.com>
+Reviewed-by: Michal Swiatkowski <michal.swiatkowski@linux.intel.com>
+Link: https://patch.msgid.link/1741644104-97767-7-git-send-email-tariqt@nvidia.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/mellanox/mlx5/core/en_main.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlx5/core/en_main.c b/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
+index a814b63ed97e57..8fcaee381b0e09 100644
+--- a/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
++++ b/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
+@@ -5132,11 +5132,9 @@ static int mlx5e_bridge_getlink(struct sk_buff *skb, u32 pid, u32 seq,
+ 	struct mlx5e_priv *priv = netdev_priv(dev);
+ 	struct mlx5_core_dev *mdev = priv->mdev;
+ 	u8 mode, setting;
+-	int err;
+ 
+-	err = mlx5_eswitch_get_vepa(mdev->priv.eswitch, &setting);
+-	if (err)
+-		return err;
++	if (mlx5_eswitch_get_vepa(mdev->priv.eswitch, &setting))
++		return -EOPNOTSUPP;
+ 	mode = setting ? BRIDGE_MODE_VEPA : BRIDGE_MODE_VEB;
+ 	return ndo_dflt_bridge_getlink(skb, pid, seq, dev,
+ 				       mode,

--- a/patch/series
+++ b/patch/series
@@ -71,6 +71,8 @@ Support-for-fullcone-nat.patch
 #
 
 0001-efi-memattr-Ignore-table-if-the-size-is-clearly-bogus.patch
+# Backport from v6.14 to v6.1.132 and v6.12.20
+0001-prevent-bridge-link-show-failure-for-non-eswitch-allowed-devices.patch
 
 # Mellanox patches for 5.10
 ###-> mellanox_sdk-start


### PR DESCRIPTION
Backport https://github.com/torvalds/linux/commit/e92df790d07a8eea873efcb84776e7b71f81c7d5 into sonic-linux-kernel
On SmartSwitch we see the following error when hostside PF interfaces (for DPUs) created by mlx5_core driver are present.

```
root@sonic:/home/admin/# bridge vlan show
port              vlan-id
***                ***
RTNETLINK answers: Operation not permitted
Dump terminated
```
Similar error is seen for bridge link show command as well.
This backport is expected to fix these issues.