### PR TITLE
Revert "ACPI: OSL: Use a threaded interrupt handler for SCI"

### DIFF
--- a/patches-sonic/revert-acpi-osl-use-threaded-irq-for-sci.patch
+++ b/patches-sonic/revert-acpi-osl-use-threaded-irq-for-sci.patch
@@ -1,0 +1,80 @@
+From: Mohan Yelugoti <ymd@arista.com>
+Date: 2026-05-11
+Subject: Revert "ACPI: OSL: Use a threaded interrupt handler for SCI"
+
+This reverts commit 7a36b901a6eb0e9945341db71ed3c45c7721cfa9.
+
+After upgrading from Debian bookworm to trixie on modular systems,
+the kdump kernel started hitting a soft lockup while capturing a
+crash dump.  The issue is reproducible by triggering a panic in the
+production kernel with:
+
+echo c | sudo tee /proc/sysrq-trigger
+
+Once the kdump kernel boots, CPU0 gets stuck in the ACPI SCI handling
+path and the soft lockup watchdog eventually panics the kdump kernel,
+so no vmcore is produced.
+
+The trace below was obtained by adding the following to the kdump
+command line: debug=1, loglevel=7, softlockup_all_cpu_backtrace=1 and
+softlockup_panic=1:
+
+    watchdog: BUG: soft lockup - CPU#0 stuck for 26s! [irq/9-acpi:39]
+    CPU: 0 UID: 0 PID: 39 Comm: irq/9-acpi Not tainted
+      6.12.41+deb13-sonic-amd64 #1  Debian 6.12.41-1
+    Hardware name: Intel Camelback Mountain CRB, BIOS
+      Aboot-norcal7-7.1.6-generic-22971530 06/30/2021
+    RIP: 0010:acpi_os_read_port+0x30/0xa0
+    Call Trace:
+     <TASK>
+     acpi_hw_gpe_read+0x61/0x80
+     acpi_ev_detect_gpe+0x74/0x180
+     acpi_ev_gpe_detect+0xe1/0x130
+     acpi_ev_sci_xrupt_handler+0x1d/0x40
+     acpi_irq+0x1c/0x40
+     irq_thread_fn+0x23/0x60
+     irq_thread+0x1b3/0x2f0
+     kthread+0xd2/0x100
+     ret_from_fork+0x34/0x50
+     ret_from_fork_asm+0x1a/0x30
+     </TASK>
+    Kernel panic - not syncing: softlockup: hung tasks
+
+Comparing the bookworm and trixie kernels, the SCI handler was moved
+from a hardirq handler to a threaded handler by the commit being
+reverted.  Moving to a threaded IRQ regressed kdump on this hardware;
+reverting that commit restores the previous hardirq-based SCI handling
+and the kdump kernel completes the crash dump without triggering the
+soft lockup watchdog.
+
+Signed-off-by: Mohan Yelugoti <ymd@arista.com>
+---
+ drivers/acpi/osl.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/acpi/osl.c b/drivers/acpi/osl.c
+--- a/drivers/acpi/osl.c
++++ b/drivers/acpi/osl.c
+@@ -544,7 +544,11 @@ acpi_os_predefined_override(const struct acpi_predefined_names *init_val,
+
+ static irqreturn_t acpi_irq(int irq, void *dev_id)
+ {
+-	if ((*acpi_irq_handler)(acpi_irq_context)) {
++	u32 handled;
++
++	handled = (*acpi_irq_handler) (acpi_irq_context);
++
++	if (handled) {
+ 		acpi_irq_handled++;
+ 		return IRQ_HANDLED;
+ 	} else {
+@@ -578,8 +582,7 @@ acpi_os_install_interrupt_handler(u32 gsi, acpi_osd_handler handler,
+
+ 	acpi_irq_handler = handler;
+ 	acpi_irq_context = context;
+-	if (request_threaded_irq(irq, NULL, acpi_irq, IRQF_SHARED | IRQF_ONESHOT,
+-			         "acpi", acpi_irq)) {
++	if (request_irq(irq, acpi_irq, IRQF_SHARED, "acpi", acpi_irq)) {
+ 		pr_err("SCI (IRQ%d) allocation failed\n", irq);
+ 		acpi_irq_handler = NULL;
+ 		return AE_NOT_ACQUIRED;

--- a/patches-sonic/series
+++ b/patches-sonic/series
@@ -40,6 +40,7 @@ driver-net-tg3-change-dma-mask-for-57766.patch
 0004-dt-bindings-hwmon-Add-missing-documentation-for-lm75.patch
 0005-dt-bindings-hwmon-Add-tmp75b-to-lm75.txt.patch
 0006-device-tree-bindinds-add-NXP-PCT2075-as-compatible-d.patch
+revert-acpi-osl-use-threaded-irq-for-sci.patch
 #Support-for-fullcone-nat.patch # TODO(trixie): update for current version
 
 #


### PR DESCRIPTION
This reverts commit [7a36b901a6eb0e9945341db71ed3c45c7721cfa9](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=7a36b901a6eb).

After upgrading from Debian bookworm to trixie on modular systems, the kdump kernel started hitting a soft lockup while capturing a crash dump.  The issue is reproducible by triggering a panic in the production kernel with:

echo c | sudo tee /proc/sysrq-trigger

Once the kdump kernel boots, CPU0 gets stuck in the ACPI SCI handling path and the soft lockup watchdog eventually panics the kdump kernel, so no vmcore is produced.

The trace below was obtained by adding the following to the kdump command line: debug=1, loglevel=7, softlockup_all_cpu_backtrace=1 and softlockup_panic=1:

    watchdog: BUG: soft lockup - CPU#0 stuck for 26s! [irq/9-acpi:39]
    CPU: 0 UID: 0 PID: 39 Comm: irq/9-acpi Not tainted
      6.12.41+deb13-sonic-amd64 #1  Debian 6.12.41-1
    Hardware name: Intel Camelback Mountain CRB, BIOS
      Aboot-norcal7-7.1.6-generic-22971530 06/30/2021
    RIP: 0010:acpi_os_read_port+0x30/0xa0
    Call Trace:
     <TASK>
     acpi_hw_gpe_read+0x61/0x80
     acpi_ev_detect_gpe+0x74/0x180
     acpi_ev_gpe_detect+0xe1/0x130
     acpi_ev_sci_xrupt_handler+0x1d/0x40
     acpi_irq+0x1c/0x40
     irq_thread_fn+0x23/0x60
     irq_thread+0x1b3/0x2f0
     kthread+0xd2/0x100
     ret_from_fork+0x34/0x50
     ret_from_fork_asm+0x1a/0x30
     </TASK>
    Kernel panic - not syncing: softlockup: hung tasks

Comparing the bookworm and trixie kernels, the SCI handler was moved from a hardirq handler to a threaded handler by the commit being reverted.  Moving to a threaded IRQ regressed kdump on this hardware; reverting that commit restores the previous hardirq-based SCI handling and the kdump kernel completes the crash dump without triggering the soft lockup watchdog.

**Which release branch to backport?** 
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

**Reason for Backport:** 

`202605` branch was cutoff before this PR was raised/merged. Since, `202605`
runs trixie too, this regression affects that particular branch as well.

**Failure type:**

Regression

**Tested branch:**
- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

Testing done: Boot a chassis with 202605 image, trigger kenel panic and check whether
the supervisor comes up as expected.

```
root@nfc405:~# show version | head -n 3

SONiC Software Version: SONiC.branch.202605-ars.159ac0ce-buildimage.0b2faef94668aef37278566e8d6277200de7a807-nightly-dbg-2026.08.12.14.39
SONiC OS Version: 13
root@nfc405:~# show reboot-cause history
Name                 Cause                                                                                                     Time                             User    Comment
-------------------  --------------------------------------------------------------------------------------------------------  -------------------------------  ------  -------------------------------------------------------------------------------------------------------------------------------------------------
2026_08_18_21_11_12  Kernel Panic                                                                                              Tue Aug 18 09:09:50 PM UTC 2026  N/A     N/A
2026_08_18_16_20_29  Power Loss (powerloss, description: mon 9 detailed fault - System lost power, time: 2026-08-18 16:11:59)  N/A                              N/A     Unknown (First boot of SONiC version branch.202605-ars.159ac0ce-buildimage.0b2faef94668aef37278566e8d6277200de7a807-nightly-dbg-2026.08.12.14.39)
```