### PR TITLE
Cherry-pick int0002 IRQF_ONESHOT removal on top of the SCI revert

### DIFF
--- a/patches-sonic/platform-x86-int0002-remove-irqf-oneshot.patch
+++ b/patches-sonic/platform-x86-int0002-remove-irqf-oneshot.patch
@@ -1,0 +1,53 @@
+From: Sebastian Andrzej Siewior <bigeasy@linutronix.de>
+Date: 2026-01-28
+Subject: platform/x86: int0002: Remove IRQF_ONESHOT from request_irq()
+
+Backport of stable commit 5938fb0e328508a50c334852e30f02ecc28b74d6
+[ Upstream commit f6bc712877f24dc89bdfd7bdbf1a32f3b9960b34 ]
+
+Passing IRQF_ONESHOT ensures that the interrupt source is masked until the
+secondary (threaded) handler is done. If only a primary handler is used
+then the flag makes no sense because the interrupt cannot fire (again)
+while its handler is running.
+
+The flag also prevents force-threading of the primary handler and the
+irq-core will warn about this.
+
+The flag was added to match the flag on the shared handler which uses a
+threaded handler and therefore IRQF_ONESHOT. This is no longer needed
+because devm_request_irq() now passes IRQF_COND_ONESHOT for this case.
+
+Revert adding IRQF_ONESHOT to irqflags.
+
+Applied here on top of revert-acpi-osl-use-threaded-irq-for-sci.patch,
+which requests the ACPI SCI with plain IRQF_SHARED again.  The INT0002
+GPIO IRQ is typically shared with the SCI, so dropping IRQF_ONESHOT here
+keeps the two request_irq() flag sets in agreement and avoids:
+
+    genirq: Flags mismatch irq 9. 00000084 (INT0002) vs. 00002080 (acpi)
+
+Fixes: 8f812373d1958 ("platform/x86: intel: int0002_vgpio: Pass IRQF_ONESHOT to request_irq()")
+Reported-by: Borah, Chaitanya Kumar <chaitanya.kumar.borah@intel.com>
+Signed-off-by: Sebastian Andrzej Siewior <bigeasy@linutronix.de>
+Signed-off-by: Thomas Gleixner <tglx@kernel.org>
+Reviewed-by: Hans de Goede <johannes.goede@oss.qualcomm.com>
+Acked-by: Ilpo Järvinen <ilpo.jarvinen@linux.intel.com>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ drivers/platform/x86/intel/int0002_vgpio.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/platform/x86/intel/int0002_vgpio.c b/drivers/platform/x86/intel/int0002_vgpio.c
+--- a/drivers/platform/x86/intel/int0002_vgpio.c
++++ b/drivers/platform/x86/intel/int0002_vgpio.c
+@@ -195,8 +195,8 @@
+ 	 * FIXME: augment this if we managed to pull handling of shared
+ 	 * IRQs into gpiolib.
+ 	 */
+-	ret = devm_request_irq(dev, irq, int0002_irq,
+-			       IRQF_ONESHOT | IRQF_SHARED, "INT0002", chip);
++	ret = devm_request_irq(dev, irq, int0002_irq, IRQF_SHARED, "INT0002",
++			       chip);
+ 	if (ret) {
+ 		dev_err(dev, "Error requesting IRQ %d: %d\n", irq, ret);
+ 		return ret;

--- a/patches-sonic/series
+++ b/patches-sonic/series
@@ -45,6 +45,7 @@ driver-net-tg3-change-dma-mask-for-57766.patch
 0005-dt-bindings-hwmon-Add-tmp75b-to-lm75.txt.patch
 0006-device-tree-bindinds-add-NXP-PCT2075-as-compatible-d.patch
 revert-acpi-osl-use-threaded-irq-for-sci.patch
+platform-x86-int0002-remove-irqf-oneshot.patch
 #Support-for-fullcone-nat.patch # TODO(trixie): update for current version
 
 #


### PR DESCRIPTION
#### Why I did it

With the ACPI SCI back on a plain `IRQF_SHARED` `request_irq()`, the INT0002 virtual GPIO
driver — which shares that IRQ line — still requests it with `IRQF_ONESHOT`. The mismatched
flags make `request_irq()` fail and `int0002_vgpio` fail to probe.

The visible symptom is a boot-time hang: after a successful ONIE install the switch freezes due to the kernel boot not progressing (~30% reproduction on SN5600). Dropping `IRQF_ONESHOT` resolves it.

#### How I did it

- Added `patches-sonic/platform-x86-int0002-remove-irqf-oneshot.patch`, backporting stable
  commit `5938fb0e3285` ("platform/x86: int0002: Remove IRQF_ONESHOT from request_irq()",
  upstream `f6bc712877f2`).
- Registered the patch in `patches-sonic/series`.

#### How to verify it

1. Build and boot a master_RC image on affected x86 hardware.
2. Confirm `int0002_vgpio` probes cleanly — `dmesg | grep -i int0002` shows no
   `IRQF_SHARED`/flags-mismatch error and no `request_irq` failure.
3. Confirm the IRQ is registered and shared: `grep int0002 /proc/interrupts`.

#### Tested branch (Please provide the tested image version)
- [x] master

#### Description for the changelog

Remove IRQF_ONESHOT from INT0002 request_irq() to fix shared-IRQ flags mismatch