### PR TITLE
driver: i2c: mv64xxx: cn9130 bus lockup issue

### DIFF
--- a/patches-sonic/0023-i2c-mv64xx-cn9130-bus-lockup-issue.patch
+++ b/patches-sonic/0023-i2c-mv64xx-cn9130-bus-lockup-issue.patch
@@ -1,0 +1,74 @@
+From 340e920894b0f3e7369905d0321221209b40ab30 Mon Sep 17 00:00:00 2001
+From: Hiral Shah <hshah@marvell.com>
+Date: Thu, 27 Aug 2026 13:49:20 -0700
+Subject: [PATCH]  i2c: mv64xxx: Fix CN9130 I2C bus lockup on cn9130 platform 
+
+On CN9130 platforms, the I2C bus enters a lockup state during
+operation. Investigation identified two root causes:
+
+1. The I2C debug slave mode (controlled via BIT(18) of the
+   config_debug register) is enabled by default and interferes
+   with normal bus transactions, causing the bus to stall.
+
+2. The Transaction Generator (offload) mode, enabled for
+   marvell,mv78230-i2c compatible devices, causes bus contention
+   on CN9130 hardware leading to lockup.
+
+Fix this by disabling the I2C debug slave during hardware
+initialization and disabling the offload mode for CN9130.
+
+These two changes are interdependent - disabling either one alone
+does not fully resolve the lockup. Both are required together to
+restore stable I2C bus operation on CN9130.
+
+Signed-off-by: Narendra Hadke <nhadke@marvell.com>
+---
+ drivers/i2c/busses/i2c-mv64xxx.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/busses/i2c-mv64xxx.c b/drivers/i2c/busses/i2c-mv64xxx.c
+index 36fdd9b192a9..f2b35f3cc346 100644
+--- a/drivers/i2c/busses/i2c-mv64xxx.c
++++ b/drivers/i2c/busses/i2c-mv64xxx.c
+@@ -118,6 +118,7 @@ struct mv64xxx_i2c_regs {
+ 	u8	status;
+ 	u8	clock;
+ 	u8	soft_reset;
++	u8	config_debug;
+ };
+ 
+ struct mv64xxx_i2c_data {
+@@ -169,6 +170,7 @@ static struct mv64xxx_i2c_regs mv64xxx_i2c_regs_mv64xxx = {
+ 	.status		= 0x0c,
+ 	.clock		= 0x0c,
+ 	.soft_reset	= 0x1c,
++	.config_debug	= 0x8c,
+ };
+ 
+ static struct mv64xxx_i2c_regs mv64xxx_i2c_regs_sun4i = {
+@@ -217,6 +219,13 @@ mv64xxx_i2c_prepare_for_io(struct mv64xxx_i2c_data *drv_data,
+ static void
+ mv64xxx_i2c_hw_init(struct mv64xxx_i2c_data *drv_data)
+ {
++	u32 data;
++
++	/* Disable I2C slave */
++	data = readl(drv_data->reg_base + drv_data->reg_offsets.config_debug);
++	data &= ~BIT(18);
++	writel(data, drv_data->reg_base + drv_data->reg_offsets.config_debug);
++
+ 	if (drv_data->offload_enabled) {
+ 		writel(0, drv_data->reg_base + MV64XXX_I2C_REG_BRIDGE_CONTROL);
+ 		writel(0, drv_data->reg_base + MV64XXX_I2C_REG_BRIDGE_TIMING);
+@@ -972,7 +981,7 @@ mv64xxx_of_config(struct mv64xxx_i2c_data *drv_data,
+ 	 * Transaction Generator support and the errata fix.
+ 	 */
+ 	if (of_device_is_compatible(np, "marvell,mv78230-i2c")) {
+-		drv_data->offload_enabled = true;
++		drv_data->offload_enabled = false;
+ 		/* The delay is only needed in standard mode (100kHz) */
+ 		if (bus_freq <= I2C_MAX_STANDARD_MODE_FREQ)
+ 			drv_data->errata_delay = true;
+-- 
+2.25.1
+

--- a/patches-sonic/series
+++ b/patches-sonic/series
@@ -182,6 +182,7 @@ cisco-npu-disable-other-bars.patch
 0018-drivers-i2c-fix-after-kdump-crash.patch
 0019-irqchip-mvebu-gicp-Clear-pending-interrupts-on-init.patch
 0022-arm64-dts-marvell-Add-DTS-for-cn9131-db-comexpress-trixie.patch
+0023-i2c-mv64xx-cn9130-bus-lockup-issue.patch
 
 # Marvell platform patches for 6.12 kernel
 0001-mmc-sdhci-cadence-Add-CN10K-eMMC-support.patch


### PR DESCRIPTION
- This patch disable offload module, and disable the "i2c debug slave"