### PR TITLE
Fully revert ACPI SCI Handler to Bookworm Behavior

### DIFF
--- a/patches-sonic/revert-acpi-ec-use-threaded-handler-for-dedicated-irq.patch
+++ b/patches-sonic/revert-acpi-ec-use-threaded-handler-for-dedicated-irq.patch
@@ -1,0 +1,45 @@
+From: Connor Roos <croos@nvidia.com>
+Date: 2026-08-05
+Subject: Revert "ACPI: EC: Use a threaded handler for dedicated IRQ"
+
+This reverts commit 655a6e7c0d83d47c36218525708c9fcfdd7f4b43.
+
+That commit moved the ACPI EC dedicated-IRQ handler to a threaded
+handler, on the grounds that commit 7a36b901a6eb ("ACPI: OSL: Use a
+threaded interrupt handler for SCI") had already made all EC code run in
+thread context on GPE-signalled systems, so the dedicated-IRQ path may as
+well match.
+
+We revert 7a36b901a6eb in
+revert-acpi-osl-use-threaded-irq-for-sci.patch, restoring hardirq
+context for the SCI.  Revert this commit too so the EC dedicated-IRQ
+path goes back to the non-threaded request_irq() handler and the EC
+interrupt handling is consistent with the pre-7a36b901a6eb behaviour.
+
+This patch and
+revert-acpi-osl-use-spin-locks-without-disabling-interrupts.patch are a
+pair: with the EC dedicated-IRQ handler back in hardirq context, ACPICA
+can once again be entered from a hardirq, so the irqsave/irqrestore
+variants that patch restores are what keep the EC path safe.  Do not
+apply one without the other, and keep both ordered after
+revert-acpi-osl-use-threaded-irq-for-sci.patch in the series.
+
+Signed-off-by: Connor Roos <croos@nvidia.com>
+---
+ drivers/acpi/ec.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/acpi/ec.c b/drivers/acpi/ec.c
+--- a/drivers/acpi/ec.c
++++ b/drivers/acpi/ec.c
+@@ -1506,8 +1506,8 @@
+
+ static bool install_gpio_irq_event_handler(struct acpi_ec *ec)
+ {
+-	return request_threaded_irq(ec->irq, NULL, acpi_ec_irq_handler,
+-				    IRQF_SHARED | IRQF_ONESHOT, "ACPI EC", ec) >= 0;
++	return request_irq(ec->irq, acpi_ec_irq_handler, IRQF_SHARED,
++			   "ACPI EC", ec) >= 0;
+ }
+
+ /**

--- a/patches-sonic/revert-acpi-osl-use-spin-locks-without-disabling-interrupts.patch
+++ b/patches-sonic/revert-acpi-osl-use-spin-locks-without-disabling-interrupts.patch
@@ -1,0 +1,59 @@
+From: Connor Roos <croos@nvidia.com>
+Date: 2026-08-05
+Subject: Revert "ACPI: OSL: Use spin locks without disabling interrupts"
+
+This reverts commit 8e57de43076477c5cce113f2579bef02ce3e8b27.
+
+That commit dropped the local interrupt disable from the ACPICA spinlock
+primitives, arguing it was no longer needed because commit 7a36b901a6eb
+("ACPI: OSL: Use a threaded interrupt handler for SCI") had moved all
+ACPICA code out of hardirq context.
+
+We revert 7a36b901a6eb in
+revert-acpi-osl-use-threaded-irq-for-sci.patch, which puts the SCI
+handler back in hardirq context.  With that revert in place the premise
+of 8e57de4307 no longer holds: ACPICA can once again run from a hardirq
+handler, so acpi_os_acquire_lock()/acpi_os_release_lock() must disable
+and restore local interrupts again.  Restore the irqsave/irqrestore
+variants.
+
+The same applies to
+revert-acpi-ec-use-threaded-handler-for-dedicated-irq.patch, which
+puts the EC dedicated-IRQ handler back in hardirq context: this patch is
+what makes that one safe.  Do not apply one without the other, and keep
+both ordered after revert-acpi-osl-use-threaded-irq-for-sci.patch in the
+series.
+
+Signed-off-by: Connor Roos <croos@nvidia.com>
+---
+ drivers/acpi/osl.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/acpi/osl.c b/drivers/acpi/osl.c
+--- a/drivers/acpi/osl.c
++++ b/drivers/acpi/osl.c
+@@ -1515,18 +1515,20 @@
+ acpi_cpu_flags acpi_os_acquire_lock(acpi_spinlock lockp)
+ 	__acquires(lockp)
+ {
+-	spin_lock(lockp);
+-	return 0;
++	acpi_cpu_flags flags;
++
++	spin_lock_irqsave(lockp, flags);
++	return flags;
+ }
+
+ /*
+  * Release a spinlock. See above.
+  */
+
+-void acpi_os_release_lock(acpi_spinlock lockp, acpi_cpu_flags not_used)
++void acpi_os_release_lock(acpi_spinlock lockp, acpi_cpu_flags flags)
+ 	__releases(lockp)
+ {
+-	spin_unlock(lockp);
++	spin_unlock_irqrestore(lockp, flags);
+ }
+
+ #ifndef ACPI_USE_LOCAL_CACHE

--- a/patches-sonic/series
+++ b/patches-sonic/series
@@ -44,8 +44,17 @@ driver-net-tg3-change-dma-mask-for-57766.patch
 0004-dt-bindings-hwmon-Add-missing-documentation-for-lm75.patch
 0005-dt-bindings-hwmon-Add-tmp75b-to-lm75.txt.patch
 0006-device-tree-bindinds-add-NXP-PCT2075-as-compatible-d.patch
+# The four patches below are one dependent set and must stay in this order.
+# The SCI revert puts the ACPI SCI back in hardirq context and requests it with
+# plain IRQF_SHARED; the three that follow restore the rest of the interrupt
+# configuration that assumed a threaded, IRQF_ONESHOT SCI.  The osl.c and ec.c
+# reverts are additionally a pair.  Dropping or reordering any of them
+# reintroduces either a genirq flags mismatch on the shared SCI line or an
+# ACPI locking deadlock.
 revert-acpi-osl-use-threaded-irq-for-sci.patch
 platform-x86-int0002-remove-irqf-oneshot.patch
+revert-acpi-osl-use-spin-locks-without-disabling-interrupts.patch
+revert-acpi-ec-use-threaded-handler-for-dedicated-irq.patch
 #Support-for-fullcone-nat.patch # TODO(trixie): update for current version
 
 #


### PR DESCRIPTION
#### Why I did it

Reverting `7a36b901a6eb` ("ACPI: OSL: Use a threaded interrupt handler for SCI") puts the ACPI SCI
back on a non-threaded handler requested with plain IRQF_SHARED. Three later upstream commits had
adjusted the surrounding code to suit the threaded, IRQF_ONESHOT SCI:

- `8e57de4307` dropped the interrupt disable from the ACPICA spin lock primitives.
- `655a6e7c0d` threaded the EC dedicated IRQ handler.
- `8f812373d1` added IRQF_ONESHOT to the INT0002 request.

Restore all three to their pre-`7a36b901a6eb` behavior, so the ACPI locking, the EC dedicated IRQ,
and the INT0002 flags match the SCI handler we restored.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Re-land `revert-acpi-osl-use-threaded-irq-for-sci.patch` (#580) and
  `platform-x86-int0002-remove-irqf-oneshot.patch` (#607), which already carries the INT0002 side.
- Add `revert-acpi-osl-use-spin-locks-without-disabling-interrupts.patch` and
  `revert-acpi-ec-use-threaded-handler-for-dedicated-irq.patch`.
- Keep the four ordered as one block in `series`, matching upstream `master`, with a comment noting
  they are a dependent set.

#### How to verify it

1. Reboot repeatedly from ONIE Install, SONiC Reboot, and Power Cycling to confirm hang does not occur on kernel start

#### Which release branch to backport (provide reason below if selected)

#### Tested branch (Please provide the tested image version)
- [x] master

#### Description for the changelog

Fully revert ACPI SCI Handler to Bookworm Behavior